### PR TITLE
Switch to Android Test Orchestrator

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,7 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments clearPackageData: 'true'
     }
 
     buildTypes {
@@ -31,6 +32,9 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
+    }
 }
 
 dependencies {
@@ -43,4 +47,5 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.3'
+    androidTestUtil 'androidx.test:orchestrator:1.4.0'
 }

--- a/app/src/androidTest/java/com/example/rodneyClicker/RavenButtonTest.kt
+++ b/app/src/androidTest/java/com/example/rodneyClicker/RavenButtonTest.kt
@@ -2,26 +2,19 @@ package com.example.rodneyClicker
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.activityScenarioRule
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class RavenButtonTest {
     @get:Rule
     var rule = activityScenarioRule<MainActivity>()
 
     @Test
     fun clickerIncrement() {
-        // Set Raven Dollars to 0
-        onView(withId(R.id.ravenDollars)).perform(replaceText("0"))
-
         // Confirm that Raven Dollars start at zero
         onView(withId(R.id.ravenDollars)).check(matches(withText("0")))
 

--- a/app/src/androidTest/java/com/example/rodneyClicker/SaveDataTest.kt
+++ b/app/src/androidTest/java/com/example/rodneyClicker/SaveDataTest.kt
@@ -31,10 +31,10 @@ class SaveDataTest {
 
         // Confirm that value increments
         onView(withId(R.id.ravenDollars)).check(matches(withText("4")))
-    }
 
-    @Test
-    fun loadData() {
+        // Recreate activity
+        rule.getScenario().recreate()
+
         // Check to see if the value is saved
         onView(withId(R.id.ravenDollars)).check(matches(withText("4")))
     }

--- a/app/src/androidTest/java/com/example/rodneyClicker/SaveDataTest.kt
+++ b/app/src/androidTest/java/com/example/rodneyClicker/SaveDataTest.kt
@@ -1,5 +1,6 @@
 package com.example.rodneyClicker
 
+import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.doubleClick
 import androidx.test.espresso.action.ViewActions.replaceText
@@ -33,7 +34,8 @@ class SaveDataTest {
         onView(withId(R.id.ravenDollars)).check(matches(withText("4")))
 
         // Recreate activity
-        rule.getScenario().recreate()
+        rule.getScenario().close()
+        launch(MainActivity::class.java)
 
         // Check to see if the value is saved
         onView(withId(R.id.ravenDollars)).check(matches(withText("4")))


### PR DESCRIPTION
This change uses Android Test Orchestrator to clear package data between test runs allowing tests to be run independently. More information is available in the [documentation](https://developer.android.com/training/testing/instrumented-tests/androidx-test-libraries/runner).