### PR TITLE
Ignore files getting committed accidentally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/androidTestResultsUserPreferences.xml
+/.idea/deploymentTargetDropDown.xml
 .DS_Store
 /build
 /captures


### PR DESCRIPTION
I noticed that a few files were committed accidentally. This change updates the `.gitignore` to exclude those files in the future.